### PR TITLE
🔀 :: [#176] 메인 화면 조회 시제 표시

### DIFF
--- a/Projects/Feature/MainFeature/Sources/MainCore.swift
+++ b/Projects/Feature/MainFeature/Sources/MainCore.swift
@@ -25,6 +25,30 @@ public struct MainCore: Reducer {
         @PresentationState public var settingsCore: SettingsCore.State?
         @PresentationState public var noticeCore: NoticeCore.State?
 
+        public var displayTitle: String {
+            let calendar = Calendar.current
+            let today = Date()
+
+            if calendar.isDate(displayDate, inSameDayAs: today) {
+                return "오늘뭐임"
+            }
+
+            if let yesterday = calendar.date(byAdding: .day, value: -1, to: today),
+               calendar.isDate(displayDate, inSameDayAs: yesterday) {
+                return "어제뭐임"
+            }
+
+            if let tomorrow = calendar.date(byAdding: .day, value: 1, to: today),
+               calendar.isDate(displayDate, inSameDayAs: tomorrow) {
+                return "내일뭐임"
+            }
+
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "ko_kr")
+            formatter.dateFormat = "EEEE"
+            return "\(formatter.string(from: displayDate))뭐임"
+        }
+
         public init() {}
     }
 

--- a/Projects/Feature/MainFeature/Sources/MainView.swift
+++ b/Projects/Feature/MainFeature/Sources/MainView.swift
@@ -89,8 +89,8 @@ public struct MainView: View {
             .background(Color.backgroundMain)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Text("ONMI")
-                        .font(.custom("Fraunces9pt-Black", size: 32))
+                    Text(viewStore.displayTitle)
+                        .twFont(.headline3)
                         .foregroundColor(.extraBlack)
                         .accessibilityHidden(true)
                 }


### PR DESCRIPTION
## 💡 개요
메인 화면 조회 시제 표시

## 📃 작업내용
메인 화면 조회 시제 표시

## 🔀 변경사항
메인 화면 조회 시제 표시



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
	- 내비게이션 타이틀이 현재 날짜에 따라 동적으로 업데이트되어, 오늘, 어제, 내일 및 기타 날짜 정보를 직관적으로 보여줍니다.
- 스타일
	- 타이틀의 글꼴과 디자인이 개선되어 보다 깔끔한 화면 구성이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->